### PR TITLE
Convert uploaded images to PNG format

### DIFF
--- a/public/pages/generator.html
+++ b/public/pages/generator.html
@@ -19,7 +19,7 @@
             <label for="skinUpload" class="required-label">Upload Image</label>
             <!--<input type="file" id="skinUpload" class="form-control" ng-model="skinUpload" ng-required="!skinUrl && !skinUser">-->
             <div ngf-drop ng-model="skinUpload" class="drop-box">
-                <button type="file" ngf-select class="btn" id="skinUpload" name="file" ng-model="skinUpload" ngf-pattern="'image/png'" ngf-accept="'image/png'" ngf-max-size="16KB" ngf-dimensions="$width == 64 && ($height == 32 || $height == 64)" ngf-run-all-validations="true" ngf-model-options="{allowInvalid: true}">Select File</button>
+                <button type="file" ngf-select class="btn" id="skinUpload" name="file" ng-model="skinUpload" ngf-pattern="'image/*'" ngf-accept="'image/*'" ngf-max-size="16KB" ngf-dimensions="$width == 64 && ($height == 32 || $height == 64)" ngf-run-all-validations="true" ngf-model-options="{allowInvalid: true}" ngf-resize="{type: 'image/png', restoreExif: false}">Select File</button>
                 <br/>
                 <div ng-show="skinUpload" style="padding-top: 4px;">
                     <img ngf-thumbnail="skinUpload" class="thumb">
@@ -28,6 +28,7 @@
                 <ul ng-show="uploadForm.file.$invalid">
                     <li ng-show="uploadForm.file.$error.dimensions">Image dimensions are {{ skinUpload.$ngfWidth }}x{{ skinUpload.$ngfHeight }}, must be either 64x32 or 64x64</li>
                     <li ng-show="uploadForm.file.$error.maxSize">Image size is {{ skinUpload.size / 1000 | number: 1 }} KB, must be at most 16 KB</li>
+                    <li ng-show="uploadForm.file.$error.pattern">Could not convert image {{ skinUpload.name }} to a PNG: Invalid image type '{{ skinUpload.name.split(".")[1] }}'</li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Currently, MineSkin only allows uploading `.png`s for skins. This PR uses the built-in image conversion functionality in `ng-file-upload`, allowing the user to upload any supported image file type. I've also added a new error message in case the conversion fails.

Note: The `restoreExif` option is used to avoid issue https://github.com/danialfarid/ng-file-upload/issues/1809#issuecomment-285974991, since `ng-file-upload` appears to unconditionally try to copy over EXIF data (which the PNG format doesn't have) when the option is (implicitly) set to `true`.